### PR TITLE
Fix data exposure in Neo4jQueryTask: log type name instead of field value

### DIFF
--- a/source/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTask.kt
+++ b/source/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTask.kt
@@ -110,7 +110,7 @@ class Neo4jQueryTask : SourceTask() {
             "value" to
                 (record.get(config.queryStreamingProperty).asObject() as? Long
                     ?: throw InvalidDataException(
-                        "Returned record does not contain a valid field ${config.queryStreamingProperty} (record.get returned '${record.get(config.queryStreamingProperty)}', expected a long value)."))),
+                        "Returned record does not contain a valid field ${config.queryStreamingProperty} (expected a long value, was ${record.get(config.queryStreamingProperty).type().name()})."))),
         config.topic,
         null,
         schema,


### PR DESCRIPTION
## Summary

Fixes CC-42193 — `Neo4jQueryTask.build()` was interpolating the raw Neo4j record field value into the `InvalidDataException` message, which then escaped `poll()` and was logged at ERROR by the Kafka Connect runtime, exposing source-database content to anyone with log access.

### Change

**`Neo4jQueryTask.kt`** — In the `build()` function, the exception message previously included `${record.get(config.queryStreamingProperty)}` (calls `toString()` on the actual field value). Replaced with `${record.get(config.queryStreamingProperty).type().name()}` which logs only the Neo4j type name (e.g. `STRING`, `INTEGER`) — safe routing metadata with no record content.

## Test plan

- [ ] Build passes
- [ ] Unit tests pass: `mvn test` / `./gradlew test`
- [ ] When `neo4j.query.streaming-property` returns a non-long field, the ERROR log contains only the property name and type, not the field value

🤖 Generated with [Claude Code](https://claude.com/claude-code)